### PR TITLE
domain kernel

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -135,7 +135,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: wasm-bindgen-cli@${{ steps.wbg.outputs.version }}
-      - run: cargo test --locked --target wasm32-unknown-unknown --test wasm
+      # `--features full` is required now that `default = []`: the wasm tests
+      # exercise the std-gated no-arg `shuffle()`/`shuffled()` and the
+      # yaml-gated `cards_from_yaml_str`, none of which exist in the pure build.
+      - run: cargo test --locked --target wasm32-unknown-unknown --features full --test wasm
 
   coverage:
     name: Coverage

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -178,3 +178,34 @@ jobs:
       - run: cargo build --locked --no-default-features --target thumbv7em-none-eabihf
       - run: cargo build --locked --no-default-features --features serde --target thumbv7em-none-eabihf
       - run: cargo build --locked --no-default-features --target thumbv7em-none-eabihf --example no_std_smoke
+
+  # The testable definition of "domain kernel": the pure (no-default-features)
+  # build must contain no I/O / format / presentation / transport crate. This
+  # gate is what makes the purity claim enforceable rather than aspirational.
+  # See docs/audit-2026-07-18-domain-kernel.md (Mode B).
+  kernel-purity:
+    name: Kernel purity (pure tree is I/O-free)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Crate names (pipe-separated) that must be ABSENT from the pure tree.
+      # Keep in sync with the `[bans].deny` list in deny.toml.
+      BANNED: "serde_norway|serde_yaml|serde_yaml_bw|colored|fluent-templates|fluent-bundle|tokio|reqwest|hyper|tonic|axum|rusqlite|sqlx"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      # 1. No banned crate may be in the pure (no-default-features) dependency tree.
+      - name: Assert pure dependency tree is I/O-free
+        run: |
+          if cargo tree --locked --no-default-features --edges normal --prefix none \
+               | sort -u | grep -E "^($BANNED) " ; then
+            echo "::error::banned crate present in the pure (no-default-features) build"
+            exit 1
+          fi
+          echo "pure kernel dependency tree is clean"
+      # 2. cargo-deny enforces the same ban list against the default graph, and
+      #    fails the build if any format/transport/runtime crate creeps in.
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny check bans

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -29,12 +29,16 @@ jobs:
         with:
           toolchain: ${{matrix.rust}}
           components: rust-src
-      - run: cargo test --locked --all
+      # `default = []` makes a bare build the pure kernel; `--features full`
+      # restores the whole convenience stack (std, i18n, colored, yaml, serde)
+      # that this job used to get for free. The pure/no-feature build is
+      # exercised separately by the `no-std-build` job below.
+      - run: cargo test --locked --all --features full
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
-      # funky is a std-only, off-by-default feature that the default-feature
-      # matrix above never compiles. Test it explicitly so regressions are gated.
-      - run: cargo test --locked --features funky
+      # funky is a std-only, off-by-default feature that `full` doesn't include.
+      # Test it explicitly (alongside full) so regressions are gated.
+      - run: cargo test --locked --features full,funky
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
@@ -52,12 +56,13 @@ jobs:
         with:
           toolchain: stable
           components: clippy, rust-src
+      # First lint the pure kernel (bare `cargo clippy` is now `default = []`).
       - run: cargo clippy --locked -- -Dclippy::all -Dclippy::pedantic
-      # Lint everything the bare `cargo clippy` above misses: the funky
-      # feature (off by default) plus all tests, examples, and benches
-      # (`--all-targets`). `unwrap`/`expect` in tests are allowed via a
-      # `cfg(test)` attribute in src/lib.rs.
-      - run: cargo clippy --locked --features funky --all-targets -- -Dclippy::all -Dclippy::pedantic
+      # Then lint the entire surface the pure build misses: every feature
+      # (`--all-features`, which covers funky, i18n, colored, yaml, serde) across
+      # all tests, examples, and benches (`--all-targets`). `unwrap`/`expect` in
+      # tests are allowed via a `cfg(test)` attribute in src/lib.rs.
+      - run: cargo clippy --locked --all-features --all-targets -- -Dclippy::all -Dclippy::pedantic
 
   fmt:
     name: Fmt

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -41,6 +41,16 @@ jobs:
       - run: cargo test --locked --features full,funky
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
+      # std-io is the opt-in filesystem seam (cards_from_yaml_file), deliberately
+      # excluded from `full`, so the runs above never exercise it. Its lib test
+      # and doctest exist only under this feature — cover them explicitly.
+      # (`--lib` and `--doc` can't be combined in one invocation.)
+      - run: cargo test --locked --features std-io --lib
+        env:
+          RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
+      - run: cargo test --locked --features std-io --doc
+        env:
+          RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
   clippy:
     name: Clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-07-18
+
+### Breaking
+
+- **`cardpack` is now pure by default: `default = []`.** A bare dependency
+  is an `alloc`-only, `no_std`, no-I/O domain kernel — no optional crates
+  are pulled in. The previous batteries-included behavior is now opt-in
+  behind a new `full` feature (`std` + `i18n` + `colored-display` +
+  `yaml` + `serde`), or via the individual features.
+  Migration: change `cardpack = "0.7"` to
+  `cardpack = { version = "0.8", features = ["full"] }` to keep prior
+  behavior, or opt into only the features you use. See the Cargo features
+  table in the README and `docs/audit-2026-07-18-domain-kernel.md`
+  (Invariant 3).
+
 ### Added
 
+- `full` umbrella feature turning on the complete convenience stack
+  (`std`, `i18n`, `colored-display`, `yaml`, `serde`) in one flag, for
+  consumers that want the pre-0.8 batteries-included behavior.
 - **`funky` feature (experimental, off by default, requires `std`)** — a
   Balatro-style scoring engine layered on the core `basic` deck, for a
   Balatro solver and for authoring custom mods. Highlights:
@@ -41,11 +59,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helper for building piles from `const` arrays. `Pile` wraps `Vec`
   and is intentionally not const-constructible. (audit row #14)
 
+### Fixed
+
+- The `Razz` deck no longer performs a runtime filesystem read to build
+  its card list. `Razz::base_vec()` previously called
+  `BasicCard::cards_from_yaml_file("src/basic/decks/yaml/razz.yaml")` —
+  a CWD-relative `std::fs` read that returned a **silent empty deck** for
+  any consumer whose working directory wasn't the crate root. The YAML is
+  now embedded at compile time via `include_str!`, so deck construction is
+  pure and correct regardless of working directory.
+  (docs/audit-2026-07-18-domain-kernel.md, Finding 1a)
+
 ### Internal
 
 - Criterion benchmarks under `benches/draw.rs` covering shuffle, draw,
   `pile_on`, and `combos` against the 108-card Canasta deck. New
   `make bench` target. (audit row #8)
+- Domain-kernel purity audit (`docs/audit-2026-07-18-domain-kernel.md`).
+  CI and Makefile test/clippy/doc targets now pass `--features full`
+  where they previously relied on default features; the `no-std-build`
+  CI job doubles as the pure-kernel gate.
 
 ## [0.7.0] — 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   switch to the pure `cards_from_yaml_str` with a compile-time `include_str!`
   (as the `Razz` deck now does). `cards_from_yaml_str` is unchanged and
   remains under `yaml`. (docs/audit-2026-07-18-domain-kernel.md, Finding 1b)
+- **Removed two unused `CardError` variants: `InvalidFilePath` and
+  `InvalidFluentRank`.** Both were declared but never constructed anywhere
+  (masked by the crate-wide `#![allow(dead_code)]`), and both leaked adapter
+  vocabulary — filesystem and i18n — into the pure kernel's public error type.
+  No code produced them, so no error handling changes; only an exhaustive
+  `match` on `CardError` naming those arms is affected. `InvalidFluentName`
+  (which *is* produced by `FluentName` parsing) is unchanged.
+  (docs/audit-2026-07-18-domain-kernel.md, Invariant 2 residue / step 5)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior, or opt into only the features you use. See the Cargo features
   table in the README and `docs/audit-2026-07-18-domain-kernel.md`
   (Invariant 3).
+- **`BasicCard::cards_from_yaml_file` moved from the `yaml` feature to a new
+  opt-in `std-io` feature** (`std-io = ["std", "yaml"]`), which is **not**
+  included in `full`. This is the crate's one filesystem seam; keeping it out
+  of `full` means both the pure kernel and the convenience stack are
+  I/O-free. Migration: enable `std-io` if you call `cards_from_yaml_file`, or
+  switch to the pure `cards_from_yaml_str` with a compile-time `include_str!`
+  (as the `Razz` deck now does). `cards_from_yaml_str` is unchanged and
+  remains under `yaml`. (docs/audit-2026-07-18-domain-kernel.md, Finding 1b)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cardpack"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ckc-rs",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cardpack"
 description = "Generic Deck of Cards"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["electronicpanopticon <gaoler@electronicpanopticon.com>"]
 repository = "https://github.com/ImperialBower/cardpack.rs.git"
 homepage = "https://github.com/ImperialBower/cardpack.rs"
@@ -22,7 +22,12 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "i18n", "colored-display", "yaml", "serde"]
+# Pure by default: a bare `cardpack` dependency is an alloc-only, no_std,
+# no-I/O domain kernel. Convenience (std, serialization, terminal color,
+# i18n, YAML) is opt-in behind `full` (or the individual features).
+# See docs/audit-2026-07-18-domain-kernel.md, Invariant 3.
+default = []
+full = ["std", "i18n", "colored-display", "yaml", "serde"]
 std = ["alloc", "rand/std", "rand/thread_rng", "serde?/std", "log/std"]
 alloc = ["serde?/alloc"]
 i18n = ["std", "dep:fluent-templates"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,12 @@ path = "src/lib.rs"
 default = []
 full = ["std", "i18n", "colored-display", "yaml", "serde"]
 std = ["alloc", "rand/std", "rand/thread_rng", "serde?/std", "log/std"]
+# The crate's one filesystem seam: `BasicCard::cards_from_yaml_file`. Kept out
+# of `full` on purpose so both the pure kernel and the convenience stack stay
+# I/O-free; opt in explicitly to read decks from YAML *files*. Deck-from-YAML
+# without the filesystem is already available via `cards_from_yaml_str` + a
+# compile-time `include_str!` (see the `Razz` deck).
+std-io = ["std", "yaml"]
 alloc = ["serde?/alloc"]
 i18n = ["std", "dep:fluent-templates"]
 colored-display = ["std", "dep:colored"]

--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,16 @@ define check_nextest
 	fi
 endef
 
-# Run unit tests via nextest
+# Run unit tests via nextest.
+# `--features full` restores the whole convenience stack now that `default = []`
+# makes a bare build the pure kernel (see docs/audit-2026-07-18-domain-kernel.md).
 test-unit:
 	$(check_nextest)
-	cargo nextest run
+	cargo nextest run --features full
 
-# Run doc tests
+# Run doc tests (doctests exercise i18n/yaml/colored APIs, so need `full`).
 test-doc:
-	cargo test --doc
+	cargo test --doc --features full
 
 # Run all tests: unit tests via nextest, doc tests via cargo test
 test: test-unit test-doc
@@ -185,14 +187,14 @@ fmt:
 # the funky feature across all targets (lib, tests, examples, benches)
 clippy:
 	cargo clippy -- -Dclippy::all -Dclippy::pedantic
-	cargo clippy --features funky --all-targets -- -Dclippy::all -Dclippy::pedantic
+	cargo clippy --all-features --all-targets -- -Dclippy::all -Dclippy::pedantic
 
 # Run the CI MSRV gate locally: the two test invocations on the 1.85 toolchain.
 # Catches post-1.85 syntax (e.g. let-chains) that stable never flags.
 # Requires: rustup toolchain install 1.85.0
 msrv:
-	cargo +1.85.0 test --locked --all
-	cargo +1.85.0 test --locked --features funky
+	cargo +1.85.0 test --locked --all --features full
+	cargo +1.85.0 test --locked --features full,funky
 
 test-nightly:
 	cargo +nightly test --all-targets --all-features
@@ -233,7 +235,7 @@ unused-deps:
 
 # Create documentation
 create_docs:
-	cargo doc --no-deps
+	cargo doc --no-deps --all-features
 
 # Open documentation in browser
 docs: create_docs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build test test-unit test-doc test-wasm build-wasm coverage bench build_test fmt clippy msrv create_docs ayce default help docs test-nightly clippy-nightly nightly miri mutants tree tree-duplicates deny audit unused-deps install-tools install-nextest install-mutants install-wasm-bindgen-cli install-llvm-cov watch install-watch no-std no-std-thumbv7
+.PHONY: clean build test test-unit test-doc test-std-io test-wasm build-wasm coverage bench build_test fmt clippy msrv create_docs ayce default help docs test-nightly clippy-nightly nightly miri mutants tree tree-duplicates deny audit unused-deps install-tools install-nextest install-mutants install-wasm-bindgen-cli install-llvm-cov watch install-watch no-std no-std-thumbv7
 
 # Default target
 default: ayce
@@ -85,8 +85,16 @@ test-unit:
 test-doc:
 	cargo test --doc --features full
 
-# Run all tests: unit tests via nextest, doc tests via cargo test
-test: test-unit test-doc
+# Exercise the opt-in filesystem seam (`cards_from_yaml_file`). It lives behind
+# the `std-io` feature, which `full` excludes, so `test-unit`/`test-doc` above
+# never touch it — its lib test and doctest exist only under this feature.
+test-std-io:
+	cargo test --features std-io --lib
+	cargo test --features std-io --doc
+
+# Run all tests: unit tests via nextest, doc tests via cargo test, plus the
+# std-io filesystem seam.
+test: test-unit test-doc test-std-io
 
 # Build cardpack for wasm32-unknown-unknown across feature combos.
 # The repo's .cargo/config.toml supplies the required getrandom backend cfg.

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,9 @@ test-wasm:
 		rustup target add wasm32-unknown-unknown; \
 	fi
 	$(check_wasm_bindgen_cli)
-	cargo test --target wasm32-unknown-unknown --test wasm
+	# --features full: the wasm tests use std-gated shuffle and yaml parsing,
+	# absent from the pure `default = []` build.
+	cargo test --target wasm32-unknown-unknown --features full --test wasm
 
 # Check for cargo-llvm-cov, prompt to install if missing.
 define check_llvm_cov
@@ -162,7 +164,9 @@ coverage:
 # Run criterion benchmarks. Output saved under target/criterion/.
 # Use `cargo bench -- --quick` for fast iteration during development.
 bench:
-	cargo bench --bench draw
+	# --features full: benches call the std-gated `shuffled()` and criterion
+	# needs std, neither of which is in the pure `default = []` build.
+	cargo bench --features full --bench draw
 
 # Check for cargo-mutants, prompt to install if missing
 define check_mutants
@@ -214,7 +218,9 @@ nightly: test-nightly clippy-nightly
 
 # Run tests under Miri
 miri:
-	cargo miri test
+	# --features full so Miri exercises the whole surface; the pure
+	# `default = []` build would otherwise run only the ungated tests.
+	cargo miri test --features full
 
 # Show dependency tree
 tree:

--- a/README.md
+++ b/README.md
@@ -96,24 +96,28 @@ what they need:
 | `std`             | no      | libstd             | `std`-only APIs (thread-RNG shuffle, `draw_random`, etc.)     |
 | `i18n`            | no      | `fluent-templates` | `FluentName`, `Named`, `Card::fluent_name*`, `localization`   |
 | `colored-display` | no      | `colored`          | `Color`, `Colorize`, `Card::color*`, `Pile::to_color_*`       |
-| `yaml`            | no      | `serde_norway`     | `BasicCard::cards_from_yaml_*`, the `Razz` deck (YAML-loaded) |
+| `yaml`            | no      | `serde_norway`     | `BasicCard::cards_from_yaml_str` (pure, in-memory), the `Razz` deck |
 | `serde`           | no      | `serde`            | `Serialize`/`Deserialize` derives on `Pip`/`Card`/`Pile` etc. |
+| `std-io`          | no      | —                  | `BasicCard::cards_from_yaml_file` — reads decks from YAML *files* (`std::fs`). The crate's one filesystem seam; **not** in `full` |
 | `funky`           | no      | `std`              | The Balatro-style engine — see [Funky](#funky--balatro-style-cards) below |
 
 To get the previous "batteries-included" behavior, opt into `full`:
 
 ```toml
 # Full convenience stack (i18n, colored display, YAML, serde):
-cardpack = { version = "0.7", features = ["full"] }
+cardpack = { version = "0.8", features = ["full"] }
 
 # Or trim to just what you need — e.g. the pure kernel plus serde:
-cardpack = { version = "0.7", features = ["serde"] }
+cardpack = { version = "0.8", features = ["serde"] }
 
 # Or the pure, no_std, alloc-only kernel with no extra deps at all:
-cardpack = "0.7"
+cardpack = "0.8"
 ```
 
 `yaml` implies `serde` (it deserializes into the serde-derived structs).
+`std-io` implies `yaml` and adds the filesystem reader on top of it; it is the
+only feature that lets the crate touch `std::fs`, and it is intentionally left
+out of `full` so the pure kernel and the convenience stack both stay I/O-free.
 
 ## Funky — Balatro-style cards
 

--- a/README.md
+++ b/README.md
@@ -85,21 +85,32 @@ internationalization. Current languages supported are
 
 ## Cargo features
 
-Every dependency-bearing capability is gated behind a Cargo feature so
-consumers can trim what they don't need:
+`cardpack` is **pure by default**: a bare dependency is an `alloc`-only,
+`no_std`, no-I/O domain kernel. Every dependency-bearing or I/O-bearing
+capability is gated behind a Cargo feature, so consumers opt in to exactly
+what they need:
 
-| Feature           | Default | Pulls in           | What turns off without it                                     |
+| Feature           | Default | Pulls in           | What it turns on                                              |
 |-------------------|---------|--------------------|---------------------------------------------------------------|
-| `i18n`            | yes     | `fluent-templates` | `FluentName`, `Named`, `Card::fluent_name*`, `localization`   |
-| `colored-display` | yes     | `colored`          | `Color`, `Colorize`, `Card::color*`, `Pile::to_color_*`       |
-| `yaml`            | yes     | `serde_norway`     | `BasicCard::cards_from_yaml_*`, the `Razz` deck (YAML-loaded) |
-| `serde`           | yes     | `serde`            | `Serialize`/`Deserialize` derives on `Pip`/`Card`/`Pile` etc. |
+| `full`            | no      | everything below   | Umbrella turning on `std` + `i18n` + `colored-display` + `yaml` + `serde` |
+| `std`             | no      | libstd             | `std`-only APIs (thread-RNG shuffle, `draw_random`, etc.)     |
+| `i18n`            | no      | `fluent-templates` | `FluentName`, `Named`, `Card::fluent_name*`, `localization`   |
+| `colored-display` | no      | `colored`          | `Color`, `Colorize`, `Card::color*`, `Pile::to_color_*`       |
+| `yaml`            | no      | `serde_norway`     | `BasicCard::cards_from_yaml_*`, the `Razz` deck (YAML-loaded) |
+| `serde`           | no      | `serde`            | `Serialize`/`Deserialize` derives on `Pip`/`Card`/`Pile` etc. |
 | `funky`           | no      | `std`              | The Balatro-style engine — see [Funky](#funky--balatro-style-cards) below |
 
-Default-features builds behave exactly like prior versions. To trim:
+To get the previous "batteries-included" behavior, opt into `full`:
 
 ```toml
-cardpack = { version = "0.6", default-features = false, features = ["serde"] }
+# Full convenience stack (i18n, colored display, YAML, serde):
+cardpack = { version = "0.7", features = ["full"] }
+
+# Or trim to just what you need — e.g. the pure kernel plus serde:
+cardpack = { version = "0.7", features = ["serde"] }
+
+# Or the pure, no_std, alloc-only kernel with no extra deps at all:
+cardpack = "0.7"
 ```
 
 `yaml` implies `serde` (it deserializes into the serde-derived structs).

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,35 @@
 msrv = "1.85"
 
 cognitive-complexity-threshold = 30
+
+# ── Domain-kernel purity lints ──────────────────────────────────────────────
+# These ban the I/O / non-determinism entry points a pure domain kernel must not
+# use, so accidental reintroduction fails `cargo clippy` (CI runs it with
+# `--all-features --all-targets`). Format / transport / i18n *crates* are banned
+# separately via cargo-deny `[bans]` in deny.toml, which keeps them out of the
+# graph entirely. See docs/audit-2026-07-18-domain-kernel.md (Invariants 1 & 4).
+#
+# Known exception: BasicCard::cards_from_yaml_file (basic_card.rs) still uses
+# std::fs::File behind the `yaml` feature and carries a local #[allow] with a
+# pointer to Finding 1b — it is slated to move to an adapter (audit step 3).
+
+disallowed-types = [
+    { path = "std::path::Path",       reason = "a kernel takes bytes/&str, not paths — an adapter owns the filesystem" },
+    { path = "std::path::PathBuf",    reason = "filesystem policy belongs in an adapter, not the kernel" },
+    { path = "std::fs::File",         reason = "no filesystem I/O in a pure kernel" },
+    { path = "std::net::TcpStream",   reason = "no network in a pure kernel" },
+    { path = "std::net::TcpListener", reason = "no network in a pure kernel" },
+    { path = "std::process::Command", reason = "no process spawning in a pure kernel" },
+]
+
+disallowed-methods = [
+    { path = "std::fs::read",           reason = "kernel must not read the filesystem" },
+    { path = "std::fs::write",          reason = "kernel must not write the filesystem" },
+    { path = "std::fs::read_to_string", reason = "kernel must not read the filesystem" },
+    { path = "std::fs::create_dir_all", reason = "kernel must not touch the filesystem" },
+    { path = "std::env::var",           reason = "kernel must not read the environment" },
+    { path = "std::env::vars",          reason = "kernel must not read the environment" },
+    # Time and randomness make the kernel non-deterministic; inject them instead.
+    # (Seeded RNG is already the pattern here — see shuffle_with_seed.)
+    { path = "std::time::SystemTime::now", reason = "inject time; a kernel is deterministic" },
+]

--- a/deny.toml
+++ b/deny.toml
@@ -47,7 +47,34 @@ highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
 allow = []
-deny = []
+# Domain-kernel purity: these format / presentation / i18n / runtime / transport
+# crates are adapter concerns and must NOT appear in the default (pure) build.
+# `[graph]` above uses default features (no-default-features = false), and
+# `default = []` makes that the pure kernel — so cargo-deny checks the pure
+# graph, where these are absent. They remain reachable behind opt-in features
+# (`yaml`, `colored-display`, `i18n`, ...). See
+# docs/audit-2026-07-18-domain-kernel.md (Invariants 2 & 4).
+deny = [
+    # Concrete serialization FORMATS (the `serde` trait itself is fine):
+    { name = "serde_norway" },
+    { name = "serde_yaml" },
+    { name = "serde_yaml_bw" },
+    # Terminal / presentation:
+    { name = "colored" },
+    # i18n / localization (embeds locale assets):
+    { name = "fluent-templates" },
+    { name = "fluent-bundle" },
+    # Async runtimes / transport / RPC / HTTP (future-proofing — not deps today):
+    { name = "tokio" },
+    { name = "async-std" },
+    { name = "reqwest" },
+    { name = "hyper" },
+    { name = "tonic" },
+    { name = "axum" },
+    # Storage engines:
+    { name = "rusqlite" },
+    { name = "sqlx" },
+]
 skip = []
 skip-tree = []
 

--- a/docs/audit-2026-07-18-domain-kernel.md
+++ b/docs/audit-2026-07-18-domain-kernel.md
@@ -1,0 +1,239 @@
+# Cardpack.rs Domain-Kernel Audit
+
+**Date:** 2026-07-18
+**Branch:** main
+**Version:** 0.7.1
+**Auditor:** Claude Code (claude-opus-4-8)
+**Framework:** [`domain-kernel` skill](https://) — Mode A (Assess)
+**Related:** [`docs/audit-2026-04-29.md`](./audit-2026-04-29.md), [`docs/audit-2026-04-09.md`](./audit-2026-04-09.md)
+
+---
+
+**Summary:** This audit assesses `cardpack` against the **domain-kernel** pattern — a
+pure, delivery-agnostic core of one domain's logic behind a narrow, stable
+boundary. The crate is closer than most: its public error surface is already
+clean (errors are boxed, not `serde_norway::Error`), and no_std/alloc/wasm/
+bare-metal builds are gated in CI. Two structural gaps stand between it and an
+honest "domain kernel" label: **the core performs filesystem I/O** (Invariant 1),
+and **`default` features turn on presentation, a YAML parser, i18n, and
+fs-loading** (Invariants 3 & 4). The deterministic purity checker reported
+**0 hard leaks, 2 warnings**. Fixes are sequenced in §5.
+
+---
+
+## 1. Framing: this is a value-type kernel, not a state-machine kernel
+
+The domain-kernel invariants are written primarily for **state-machine kernels**
+(game state + actions + emitted events, e.g. poker *gameplay*). `cardpack` is a
+**value/collection library** — cards, pips, piles, decks. It has no game state,
+no acting parties, and no hidden information.
+
+That distinction is load-bearing for the assessment:
+
+- **Invariant 5** (hidden-information projection, `view_for(state, actor)`) — **N/A.**
+  There is nothing to project.
+- **Invariant 6** (narrow transition surface `to_act`/`apply`/`legal_actions` →
+  WIT world) — **N/A in the ideal form.** `cardpack`'s surface is inherently broad
+  (13 decks, `Pile`, `Card`, `BasicCard`, combos, the `funky`/Balatro module). A
+  language-neutral WIT boundary (**Mode C**) is a poor fit for this crate and is
+  **not recommended** unless a specific cross-language consumer appears. The kernel
+  value here is **purity + portability** (no_std/wasm), not a transition contract.
+
+Everything below therefore focuses on Invariants 1–4.
+
+---
+
+## 2. Methodology
+
+- Ran `scripts/check_purity.py` against the crate root (0 hard, 2 warn).
+- Read `references/invariants.md` and checked each invariant by hand.
+- Reviewed: `Cargo.toml`, `src/lib.rs`, `src/basic/types/basic_card.rs`,
+  `src/basic/decks/razz.rs`, `src/localization.rs`, `src/common/errors.rs`,
+  `deny.toml`, `clippy.toml`, `.github/workflows/CI.yaml`.
+- Grepped non-test `src/` for `std::fs`/`std::net`/`std::env`/`Path`/`tokio`/
+  `reqwest` and for format-crate/i18n leaks.
+
+---
+
+## 3. Scorecard
+
+| # | Invariant | Status | Severity |
+|---|-----------|--------|----------|
+| 1 | Pure — no I/O of its own | 🔴 Violated | High |
+| 2 | No format/transport crate in public API | 🟢 Satisfied | — |
+| 3 | Pure by default | 🔴 Violated | High |
+| 4 | Delivery-agnostic | 🟡 Partial | Medium |
+| 5 | Hidden-information projection | ⚪ N/A | — |
+| 6 | Narrow, stable transition boundary | ⚪ N/A | — |
+
+---
+
+## 4. Findings
+
+### 🔴 Invariant 1 — Pure (no I/O of its own) — VIOLATED
+
+#### Finding 1a — a deck reads a hardcoded path at construction time *(highest leverage)*
+
+`src/basic/decks/razz.rs:30`
+
+```rust
+fn base_vec() -> Vec<BasicCard> {
+    BasicCard::cards_from_yaml_file("src/basic/decks/yaml/razz.yaml").unwrap_or_else(|e| {
+        error!("Failed to load Razz deck from YAML: {e}");
+        Vec::default()
+    })
+}
+```
+
+The most serious purity violation in the crate. Building `Pile::<Razz>::deck()`
+opens a file **relative to the current working directory**. It only works because
+tests run from the crate root with the `.yaml` bundled — for any real downstream
+consumer, `Razz::base_vec()` silently returns an **empty deck** and logs an error.
+The kernel is asserting a CWD layout, performing I/O, *and* swallowing the failure.
+Every other deck (`french.rs`, etc.) builds `base_vec` programmatically from
+`const` data; Razz is the lone outlier.
+
+> Note: the 2026-04-29 audit recorded the `log::error!` addition here as a *fix*
+> for silent failure. From a kernel-purity standpoint the logging is a symptom —
+> the underlying runtime fs read is the defect.
+
+**Fix (near-zero risk):** embed the data at compile time instead of reading it at runtime.
+
+```rust
+fn base_vec() -> Vec<BasicCard> {
+    // include_str! bakes the file into the binary at build time — no fs, no CWD.
+    BasicCard::cards_from_yaml_str(include_str!("yaml/razz.yaml"))
+        .expect("razz.yaml is bundled and validated in tests")
+}
+```
+
+Keeps the "yaml-driven deck" demonstration, removes the runtime filesystem
+dependency and the silent-empty-deck failure mode. Couples Razz to the `yaml`
+feature, which is the correct coupling.
+
+#### Finding 1b — a public constructor takes a path and reads it
+
+`src/basic/types/basic_card.rs:78`
+
+```rust
+#[cfg(feature = "yaml")]
+pub fn cards_from_yaml_file(file_path: &str) -> Result<Vec<Self>, Box<dyn Error>> {
+    let mut file = File::open(file_path)?;
+    ...
+}
+```
+
+Per Invariant 1, "a method that takes a path is I/O policy living in the kernel."
+The pure sibling `cards_from_yaml_str(&str)` (line 93) already does the real work;
+`cards_from_yaml_file` is a thin fs wrapper.
+
+**Fix:** relocate `cards_from_yaml_file` to an adapter (an example, a `cardpack-io`
+companion, or a `std-io` feature that is **not** in `default`). Keep
+`cards_from_yaml_str` in the core. After Finding 1a, nothing inside the crate needs
+the file variant.
+
+> `static_loader!` in `src/localization.rs:8` reads locale files at **compile
+> time** (fluent-templates embeds them), so it is not a runtime purity violation.
+> It is still a heavy default dependency — see Invariant 3.
+
+---
+
+### 🟢 Invariant 2 — No format/transport crate in the public API — SATISFIED
+
+`serde_norway` never appears in a public signature — the YAML methods return
+`Result<_, Box<dyn Error>>`, boxing the format error at the seam exactly as the
+invariant prescribes. `serde::{Serialize, Deserialize}` are derived under
+`#[cfg(feature = "serde")]` — a *trait* dependency, not a concrete format, which is
+allowed.
+
+Only cosmetic residue remains: method *names* (`cards_from_yaml_*`) and
+`CardError::InvalidFilePath` (`src/common/errors.rs:15`) mention format/fs
+concerns. These are later renames, not couplings — defer until after the
+structural fixes.
+
+---
+
+### 🔴 Invariant 3 — Pure by default — VIOLATED *(highest leverage, tie with 1a)*
+
+`Cargo.toml`:
+
+```toml
+default = ["std", "i18n", "colored-display", "yaml", "serde"]
+```
+
+A bare `cargo add cardpack` currently pulls in:
+
+| Default feature | Drags in | Kernel concern? |
+|---|---|---|
+| `std` | libstd | couples to std; a kernel should default to `alloc` |
+| `i18n` | `fluent-templates` (+ embedded locales) | presentation / localization |
+| `colored-display` | `colored` | **terminal presentation** (delivery — see Inv. 4) |
+| `yaml` | `serde_norway` | **format crate** + unlocks the fs-reading methods |
+| `serde` | `serde` | serialization |
+
+This is the standard kernel headline fix, and the crate is already structured for
+it — every feature is cleanly gated and a `no-std-build` CI job already proves
+`--no-default-features` compiles:
+
+```toml
+default = []                                                 # pure core (or ["alloc"])
+full = ["std", "i18n", "colored-display", "yaml", "serde"]   # opt-in umbrella
+```
+
+**Ripple to handle:** examples/tests with `required-features` **error rather than
+skip** under empty defaults, and Makefile/CI invocations that relied on default
+features must pass `--features full`.
+
+---
+
+### 🟡 Invariant 4 — Delivery-agnostic — PARTIAL
+
+`colored-display` puts `colored::Color` into the core (`colors() -> HashMap<Pip,
+Color>` in the deck impls) and it is **on by default**. Terminal coloring is a
+*rendering* concern — textbook adapter material. It is feature-gated, so the
+immediate fix is removing it from `default` (Invariant 3); the longer-term fix is
+relocating the color maps into a `cardpack-display` adapter.
+
+No `clap`/`axum`/`tonic`/web types in the core (`clap` is a dev-dep for examples
+only). `log::error!` in `razz.rs` is a facade call — minor, and it disappears when
+Finding 1a is fixed.
+
+---
+
+## 5. Recommended sequence
+
+Ordered by leverage-to-risk (matches the skill's "flip default + de-leak first"
+guidance):
+
+1. **Fix Razz's hidden fs I/O** (1a) — swap runtime `cards_from_yaml_file` for
+   compile-time `include_str!`. Removes the worst violation and the silent
+   empty-deck bug. ~10 lines, near-zero risk.
+2. **Flip `default` to `[]` (or `["alloc"]`) and add a `full` umbrella** (Inv. 3).
+   Wire `--features full` into the Makefile/CI targets that assumed default
+   features. Biggest purity win; the gating already exists.
+3. **Move `cards_from_yaml_file` to an adapter / `std-io` opt-in feature** (1b),
+   keeping the pure `cards_from_yaml_str` in the core.
+4. **(Enforce — Mode B)** Add `clippy.toml` `disallowed-types`/`disallowed-methods`
+   for `std::fs`/`std::net`/`std::env`, and a CI job asserting banned crates
+   (`serde_norway`, `colored`, `fluent-templates`) are absent from the
+   `--no-default-features` `cargo tree`. Makes "kernel" a testable property. The
+   existing `deny.toml` and `no-std-build` job are ~80% of the scaffolding.
+5. **(Later, cosmetic)** Relocate `colored`/i18n presentation into adapter crates;
+   rename `InvalidFilePath` and the `*_yaml_*` methods.
+
+**Not recommended:** Mode C (WIT / wasm-component boundary). `cardpack` is a
+value-type library with a deliberately broad surface; a language-neutral
+transition contract does not fit and would add ceremony without a consumer. Revisit
+only if a non-Rust driver materializes.
+
+---
+
+## 6. What "done" looks like
+
+- `cargo build --no-default-features` yields a pure `alloc`-only kernel: no
+  `std::fs`, no `colored`, no `serde_norway`, no `fluent-templates`.
+- `cargo tree --no-default-features` contains none of the banned crates, asserted
+  in CI.
+- Constructing any deck — including Razz — performs zero runtime I/O.
+- Convenience (YAML load-from-file, colored display, i18n, serde) lives behind the
+  `full` umbrella or in adapter crates, opt-in.

--- a/src/basic/decks/razz.rs
+++ b/src/basic/decks/razz.rs
@@ -27,8 +27,14 @@ pub struct Razz {}
 
 impl DeckedBase for Razz {
     fn base_vec() -> Vec<BasicCard> {
-        BasicCard::cards_from_yaml_file("src/basic/decks/yaml/razz.yaml").unwrap_or_else(|e| {
-            error!("Failed to load Razz deck from YAML: {e}");
+        // Razz ships its card list as YAML to demonstrate config-driven decks.
+        // `include_str!` embeds that YAML at build time, so deck construction
+        // stays pure: no `std::fs`, no CWD-relative path, unlike the old runtime
+        // `cards_from_yaml_file` read that returned a silent empty deck for any
+        // consumer whose working directory wasn't the crate root.
+        // See docs/audit-2026-07-18-domain-kernel.md, Finding 1a.
+        BasicCard::cards_from_yaml_str(include_str!("yaml/razz.yaml")).unwrap_or_else(|e| {
+            error!("Failed to parse embedded Razz YAML: {e}");
             Vec::default()
         })
     }

--- a/src/basic/types/basic_card.rs
+++ b/src/basic/types/basic_card.rs
@@ -12,7 +12,13 @@ use core::fmt;
 use core::fmt::Display;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+// Finding 1b (docs/audit-2026-07-18-domain-kernel.md): this filesystem read is
+// the last remaining I/O in the core and is slated to move to an adapter in
+// audit step 3. Until then it is *explicitly* exempted from the kernel purity
+// lint (clippy `disallowed_types`, see clippy.toml) rather than silently — the
+// `#[allow]` is the paper trail for the exception.
 #[cfg(feature = "yaml")]
+#[allow(clippy::disallowed_types)]
 use std::fs::File;
 #[cfg(feature = "yaml")]
 use std::io::Read;
@@ -75,6 +81,7 @@ impl BasicCard {
     ///
     /// Throws an error for an invalid path or invalid data.
     #[cfg(feature = "yaml")]
+    #[allow(clippy::disallowed_types)] // Finding 1b — see the `use std::fs::File` note above.
     pub fn cards_from_yaml_file(file_path: &str) -> Result<Vec<Self>, Box<dyn Error>> {
         let mut file = File::open(file_path)?;
         let mut contents = String::new();

--- a/src/basic/types/basic_card.rs
+++ b/src/basic/types/basic_card.rs
@@ -12,15 +12,16 @@ use core::fmt;
 use core::fmt::Display;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-// Finding 1b (docs/audit-2026-07-18-domain-kernel.md): this filesystem read is
-// the last remaining I/O in the core and is slated to move to an adapter in
-// audit step 3. Until then it is *explicitly* exempted from the kernel purity
-// lint (clippy `disallowed_types`, see clippy.toml) rather than silently — the
-// `#[allow]` is the paper trail for the exception.
-#[cfg(feature = "yaml")]
+// The `std-io` feature is the crate's one deliberate filesystem seam: it gates
+// `cards_from_yaml_file` and nothing else. It is opt-in and NOT part of `full`,
+// so the pure kernel and the convenience stack both stay I/O-free. The
+// `#[allow]` documents that this `std::fs` use is the intended seam rather than
+// an accidental leak past the kernel purity lint (clippy `disallowed_types`,
+// see clippy.toml). See docs/audit-2026-07-18-domain-kernel.md (Finding 1b).
+#[cfg(feature = "std-io")]
 #[allow(clippy::disallowed_types)]
 use std::fs::File;
-#[cfg(feature = "yaml")]
+#[cfg(feature = "std-io")]
 use std::io::Read;
 
 /// Intermediary struct to help mix and match cards for related decks.
@@ -65,8 +66,16 @@ impl BasicCard {
         Self { suit, rank }
     }
 
-    /// Reads in a YAML file version of `BasicCard` data at the passed in location and returns a vector of `BasicCards`. See the
-    /// [`Razz`](crate::basic::decks::razz::Razz) deck for an example of how to use this method.
+    /// Reads a YAML file of `BasicCard` data at the given path and returns a vector of `BasicCards`.
+    ///
+    /// Requires the opt-in `std-io` feature — this is the crate's one filesystem
+    /// seam and is deliberately outside the pure kernel and the `full` bundle.
+    /// For a pure alternative, embed the YAML at compile time with `include_str!`
+    /// and call [`cards_from_yaml_str`](Self::cards_from_yaml_str), as the
+    /// [`Razz`](crate::basic::decks::razz::Razz) deck does.
+    ///
+    /// This example (like the function) exists only under the `std-io` feature,
+    /// so it runs when the doctests are built with `std-io` enabled:
     ///
     /// ```
     /// use cardpack::prelude::*;
@@ -80,8 +89,8 @@ impl BasicCard {
     /// # Errors
     ///
     /// Throws an error for an invalid path or invalid data.
-    #[cfg(feature = "yaml")]
-    #[allow(clippy::disallowed_types)] // Finding 1b — see the `use std::fs::File` note above.
+    #[cfg(feature = "std-io")]
+    #[allow(clippy::disallowed_types)] // Intentional `std-io` filesystem seam — see the import note above.
     pub fn cards_from_yaml_file(file_path: &str) -> Result<Vec<Self>, Box<dyn Error>> {
         let mut file = File::open(file_path)?;
         let mut contents = String::new();
@@ -209,7 +218,7 @@ mod basic__types__basic_card_tests {
     use core::str::FromStr;
     use rstest::rstest;
 
-    #[cfg(feature = "yaml")]
+    #[cfg(feature = "std-io")]
     #[test]
     fn cards_from_yaml_file() {
         let cards = BasicCard::cards_from_yaml_file("src/basic/decks/yaml/french.yaml").unwrap();

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -12,16 +12,10 @@ pub enum CardError {
     #[error("Invalid Card Count: `{0}`")]
     InvalidCardCount(usize),
 
-    #[error("Invalid File Path: `{0}`")]
-    InvalidFilePath(String),
-
     #[error(
         "Invalid FluentName: `{0}`. Must be alphanumeric with hyphens, en-dashes, or em-dashes."
     )]
     InvalidFluentName(String),
-
-    #[error("Invalid Fluent Rank: `{0}`. Must be single char.")]
-    InvalidFluentRank(String),
 
     #[error("Invalid Index: `{0}`")]
     InvalidIndex(String),


### PR DESCRIPTION
Features
  - Pure-by-default domain kernel: default = [] + new full umbrella feature (Cargo.toml)
  - New opt-in std-io feature isolating the crate's only filesystem seam (cards_from_yaml_file)

  Fixes
  - Razz deck no longer does a runtime std::fs read — YAML embedded via include_str! (fixes silent empty-deck)

  Refactors
  - Moved cards_from_yaml_file from yaml to std-io feature (out of default and full)
  - Removed dead CardError::InvalidFilePath / InvalidFluentRank variants (fs/i18n vocab out of kernel error type)

  Config/docs
  - Enforcement: clippy I/O bans + cargo-deny crate bans + CI kernel-purity job asserting a clean pure dependency tree
  - CI/Makefile: test/clippy/doc targets pass --features full; added std-io test legs
  - Added domain-kernel purity audit (docs/audit-2026-07-18-domain-kernel.md)
  - README feature table rewritten for pure-by-default; CHANGELOG 0.8.0 breaking entries
  - Version bumped 0.7.1 → 0.8.0